### PR TITLE
Send thank you email on completion(#425)

### DIFF
--- a/djaopsp/api/samples.py
+++ b/djaopsp/api/samples.py
@@ -30,6 +30,7 @@ from ..pagination import BenchmarksPagination
 from ..queries import get_scored_assessments
 from ..scores import (freeze_scores, get_score_calculator,
     populate_scorecard_cache)
+from ..signals import sample_frozen
 from ..utils import get_practice_serializer, get_scores_tree, get_score_weight
 from .campaigns import CampaignContentMixin
 from .rollups import GraphMixin, RollupMixin
@@ -155,6 +156,9 @@ class AssessmentCompleteAPIView(SectionReportMixin, TimersMixin,
                             frozen_assessment_sample, calculator,
                             segment_path, segment_title)
             self._report_queries("freezing assessment: scorecard cache created")
+        
+        # After a sample is frozen, send the signal.
+        sample_frozen.send(sender=self.__class__, sample=frozen_assessment_sample, request=request)
 
         # Next step in the assessment. After complete, scorecard is optional.
         next_url = reverse('share', args=(

--- a/djaopsp/notifications/serializers.py
+++ b/djaopsp/notifications/serializers.py
@@ -3,7 +3,7 @@
 
 from rest_framework import serializers
 from survey.api.serializers import (NoModelSerializer,
-    InviteeSerializer as ProfileSerializer, CampaignSerializer)
+    InviteeSerializer as ProfileSerializer, CampaignSerializer, SampleSerializer)
 
 from ..compat import gettext_lazy as _
 
@@ -59,3 +59,15 @@ class PortfolioNotificationSerializer(NotificationSerializer):
             'message',)
         read_only_fields = ('grantee', 'account', 'campaign',
             'last_completed_at',)
+
+class SampleFrozenNotificationSerializer(NotificationSerializer):
+    # Needs to be updated depending on how we end up
+    # getting the profile managers.
+    account = ProfileSerializer()
+    campaign = CampaignSerializer(required=False)
+    last_completed_at = serializers.CharField(required=False)
+    sample = SampleSerializer()
+
+    class Meta:
+        fields = ('account', 'campaign', 'last_completed_at', 'sample')
+

--- a/djaopsp/notifications/serializers.py
+++ b/djaopsp/notifications/serializers.py
@@ -61,13 +61,9 @@ class PortfolioNotificationSerializer(NotificationSerializer):
             'last_completed_at',)
 
 class SampleFrozenNotificationSerializer(NotificationSerializer):
-    # Needs to be updated depending on how we end up
-    # getting the profile managers.
     account = ProfileSerializer()
-    campaign = CampaignSerializer(required=False)
-    last_completed_at = serializers.CharField(required=False)
     sample = SampleSerializer()
 
     class Meta:
-        fields = ('account', 'campaign', 'last_completed_at', 'sample')
+        fields = ('account', 'sample')
 

--- a/djaopsp/notifications/signals.py
+++ b/djaopsp/notifications/signals.py
@@ -170,16 +170,7 @@ def send_sample_frozen_notification(sender, sample, request, **kwargs):
 
     #pylint:disable=unused-argument
     LOGGER.debug("[signal] send_sample_frozen_notification(sample=%s)", sample)
-    
-    # Trying to figure out how exactly to access the profile managers.
-    # send_notification defaults to sending to the broker profile managers, but
-    # we need the sample's account's profile managers.
 
-    # Not sure if we use the Portfolio model and access
-    # its grantees based on whether their access is active(?)
-    # portfolios = Portfolio.objects.filter(account=sample.account, ends_at__lte=datetime.now())
-    # grantees = portfolios.values('grantee')
-    # and send an email to all of them
     broker = request.session.get('site', {})
     context = {
        'broker': {

--- a/djaopsp/notifications/signals.py
+++ b/djaopsp/notifications/signals.py
@@ -8,9 +8,10 @@ from survey.signals import (portfolios_grant_initiated,
     portfolios_request_initiated, portfolio_request_accepted)
 
 from ..compat import reverse
+from ..signals import sample_frozen
 from ..utils import send_notification, get_latest_completed_assessment
 from .serializers import (PortfolioGrantInitiatedSerializer,
-    PortfolioNotificationSerializer)
+    PortfolioNotificationSerializer, SampleFrozenNotificationSerializer)
 
 LOGGER = logging.getLogger(__name__)
 
@@ -158,3 +159,41 @@ def portfolio_request_accepted_notice(sender, portfolio, request, **kwargs):
     }
     send_notification('portfolio_request_accepted',
         context=PortfolioNotificationSerializer().to_representation(context))
+
+
+@receiver(sample_frozen,
+    dispatch_uid="sample_frozen")
+def send_sample_frozen_notification(sender, sample, request, **kwargs):
+
+    back_url = request.build_absolute_uri(reverse('scorecard',
+        args=(sample.account, sample)))
+
+    #pylint:disable=unused-argument
+    LOGGER.debug("[signal] send_sample_frozen_notification(sample=%s)", sample)
+    
+    # Trying to figure out how exactly to access the profile managers.
+    # send_notification defaults to sending to the broker profile managers, but
+    # we need the sample's account's profile managers.
+
+    # Not sure if we use the Portfolio model and access
+    # its grantees based on whether their access is active(?)
+    # portfolios = Portfolio.objects.filter(account=sample.account, ends_at__lte=datetime.now())
+    # grantees = portfolios.values('grantee')
+    # and send an email to all of them
+    broker = request.session.get('site', {})
+    context = {
+       'broker': {
+            'slug': settings.APP_NAME,
+            'full_name': broker.get('printable_name'),
+            'printable_name': broker.get('printable_name'),
+            'email': broker.get('email')
+        },
+        'account': sample.account,
+        'back_url': back_url,
+        'campaign': sample.campaign,
+        'originated_by': request.user,
+        'sample': sample
+    }
+
+    send_notification('sample_frozen_event',
+        context=SampleFrozenNotificationSerializer().to_representation(context))

--- a/djaopsp/signals.py
+++ b/djaopsp/signals.py
@@ -1,0 +1,3 @@
+from django.dispatch import Signal
+
+sample_frozen = Signal(providing_args=["sample", "request"])

--- a/djaopsp/templates/notification/sample_frozen_event.eml
+++ b/djaopsp/templates/notification/sample_frozen_event.eml
@@ -10,7 +10,7 @@ Sample Frozen Notification
 
 {% block html_content %}
 <p>Hello,</p>
-<p>A sample has been successfully frozen in your campaign <strong>{{ campaign.title }}</strong>.</p>
+<p>A sample has been successfully frozen in your campaign <strong>{% if sample.campaign %}{{sample.campaign.title}} {% endif %}</strong>.</p>
 <p>Details of the frozen sample:</p>
 <ul>
     <li>Account: {{ account.full_name }}</li>

--- a/djaopsp/templates/notification/sample_frozen_event.eml
+++ b/djaopsp/templates/notification/sample_frozen_event.eml
@@ -1,0 +1,20 @@
+{% extends "notification/base.eml" %}
+
+{% block subject %}
+Sample Frozen Notification
+{% endblock %}
+
+{% block title %}
+{{ broker.printable_name }} - Sample Frozen
+{% endblock %}
+
+{% block html_content %}
+<p>Hello,</p>
+<p>A sample has been successfully frozen in your campaign <strong>{{ campaign.title }}</strong>.</p>
+<p>Details of the frozen sample:</p>
+<ul>
+    <li>Account: {{ account.full_name }}</li>
+    <li>Frozen by: {{ originated_by.username }}</li>
+    <li>Frozen at: {{ sample.updated_at }}</li>
+</ul>
+{% endblock %}

--- a/djaopsp/utils.py
+++ b/djaopsp/utils.py
@@ -110,6 +110,12 @@ def _notified_recipients(notification_slug, context):
         user_email = context.get('grantee', {}).get('email', "")
         if user_email:
             recipients = [user_email]
+    elif notification_slug in ('sample_frozen_event'):
+        # This only gets a single email address and for the broker
+        # as well.
+        user_email = context.get('broker', {}).get('email', "")
+        if user_email:
+            recipients = [user_email]
 
     return recipients, bcc, reply_to
 

--- a/djaopsp/utils.py
+++ b/djaopsp/utils.py
@@ -100,7 +100,8 @@ def _notified_recipients(notification_slug, context):
         originated_by = {}
 
     if notification_slug in (
-            'portfolios_request_initiated',):
+            'portfolios_request_initiated',
+            'sample_frozen_event'):
         user_email = context.get('account', {}).get('email', "")
         if user_email:
             recipients = [user_email]
@@ -108,12 +109,6 @@ def _notified_recipients(notification_slug, context):
             'portfolios_grant_initiated',
             'portfolio_request_accepted',):
         user_email = context.get('grantee', {}).get('email', "")
-        if user_email:
-            recipients = [user_email]
-    elif notification_slug in ('sample_frozen_event'):
-        # This only gets a single email address and for the broker
-        # as well.
-        user_email = context.get('broker', {}).get('email', "")
         if user_email:
             recipients = [user_email]
 


### PR DESCRIPTION
- `api/samples.py`: Added a signal send on the APIView once a sample is frozen
- `notifications.serializers.py`: Added a SampleFrozenNotificationSerializer
- `notifications/signals.py`: Added signal receiver for sending a notification for the frozen sample
- `signals.py`: Added the frozen sample signal
- `sample_frozen_event.eml`: Added an email template

Currently working on:
- Correctly access the profile managers for the account the sample/survey was completed on
- Testing the email sending and making other fixes/updates