### PR TITLE
Add model, API and views to attach surveys to sequences(#423)

### DIFF
--- a/djaopsp/fixtures/content.json
+++ b/djaopsp/fixtures/content.json
@@ -4204,5 +4204,107 @@
     "account": 3
   },
   "model": "pages.PageElement", "pk": 600
-}
+},
+  {
+    "fields": {
+      "title": "Text Content",
+      "slug": "text-content",
+      "text": "<p>Some text content here.</p>",
+      "account": 2
+    },
+    "model": "pages.PageElement", "pk": 100
+  },
+  {
+    "fields": {
+      "title": "Survey Event",
+      "slug": "survey-event",
+      "text": "<p>Survey details here.</p>",
+      "account": 2
+    },
+    "model": "pages.PageElement", "pk": 101
+  },
+  {
+    "fields": {
+      "title": "Live Webinar Event",
+      "slug": "live-webinar-event",
+      "text": "<p>Details about the webinar.</p>",
+      "account": 2
+    },
+    "model": "pages.PageElement", "pk": 102
+  },
+  {
+    "fields": {
+      "title": "Certificate of Completion",
+      "slug": "certificate-completion",
+      "text": "<p>Certificate details here.</p>",
+      "account": 2
+    },
+    "model": "pages.PageElement", "pk": 103
+  },
+  {
+    "fields": {
+      "element": 101,
+      "created_at": "2023-03-20T12:00:00Z",
+      "campaign": 1,
+      "extra": "{\"questionnaire_id\":123, \"additional_info\":\"Survey extra data\"}"
+    },
+    "model": "djaopsp.SurveyEvent", "pk": 300
+  },
+  {
+    "fields": {
+      "element": 102,
+      "created_at": "2023-03-21T15:00:00Z",
+      "scheduled_at": "2023-04-15T15:00:00Z",
+      "location": "http://127.0.0.1:8000/webinar/live-event",
+      "max_attendees": 100,
+      "extra": "{}"
+    },
+    "model": "pages.LiveEvent", "pk": 301
+  },
+  {
+    "fields": {
+      "title": "Sequence with Various Elements",
+      "slug": "seq-various-elements",
+      "account": 2,
+      "has_certificate": true,
+      "created_at": "2023-01-04T00:00:00Z"
+    },
+    "model": "pages.Sequence", "pk": 104
+  },
+  {
+    "fields": {
+      "sequence": 104,
+      "page_element": 100,
+      "rank": 1,
+      "min_viewing_duration": "00:00:10"
+    },
+    "model": "pages.EnumeratedElements", "pk": 111
+  },
+  {
+    "fields": {
+      "sequence": 104,
+      "page_element": 101,
+      "rank": 2,
+      "min_viewing_duration": "00:00:20"
+    },
+    "model": "pages.EnumeratedElements", "pk": 112
+  },
+  {
+    "fields": {
+      "sequence": 104,
+      "page_element": 102,
+      "rank": 3,
+      "min_viewing_duration": "00:00:30"
+    },
+    "model": "pages.EnumeratedElements", "pk": 113
+  },
+  {
+    "fields": {
+      "sequence": 104,
+      "page_element": 103,
+      "rank": 4,
+      "min_viewing_duration": "00:00:00"
+    },
+    "model": "pages.EnumeratedElements", "pk": 114
+  }
 ]

--- a/djaopsp/mixins.py
+++ b/djaopsp/mixins.py
@@ -10,7 +10,8 @@ from django.db import transaction
 from django.db.models import Q, F
 from django.http import Http404
 from django.utils.translation import ugettext_lazy as _
-from pages.mixins import TrailMixin
+from pages.mixins import (TrailMixin, 
+    SequenceProgressMixin as SequenceProgressMixinBase)
 from pages.models import PageElement
 from survey.helpers import get_extra
 from survey.mixins import (CampaignMixin as CampaignMixinBase,
@@ -21,7 +22,7 @@ from survey.settings import URL_PATH_SEP, DB_PATH_SEP
 from survey.utils import get_question_model
 
 from .compat import reverse
-from .models import VerifiedSample
+from .models import VerifiedSample, SurveyEvent
 from .utils import (get_account_model, get_requested_accounts,
     get_segments_available, get_segments_candidates)
 
@@ -644,3 +645,9 @@ class AccountsNominativeQuerysetMixin(AccountsAggregatedQuerysetMixin):
         if not hasattr(self, '_requested_accounts'):
             self._requested_accounts = self.get_requested_accounts(self.account)
         return self._requested_accounts
+
+class SequenceProgressMixin(SequenceProgressMixinBase):
+
+    def update_element(self, obj):
+        super(SequenceProgressMixin, self).update_element(obj)
+        obj.is_survey_event = SurveyEvent.objects.filter(element=obj.page_element).exists()

--- a/djaopsp/models.py
+++ b/djaopsp/models.py
@@ -4,7 +4,8 @@
 from django.conf import settings as django_settings
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-from survey.models import Sample, get_extra_field_class
+from survey.models import Sample, get_extra_field_class, Campaign
+from pages.models import PageElement
 
 from .compat import python_2_unicode_compatible
 
@@ -99,3 +100,16 @@ class VerifiedSample(models.Model):
 
     def __str__(self):
         return str(self.sample.slug)
+
+
+class SurveyEvent(models.Model):
+    element = models.ForeignKey(PageElement, on_delete=models.CASCADE,
+                              related_name='surveys')
+    created_at = models.DateTimeField(editable=False, auto_now_add=True)
+    campaign = models.ForeignKey(Campaign, on_delete=models.CASCADE,
+                                 related_name='campaigns')
+    extra = get_extra_field_class()(null=True, blank=True,
+        help_text=_("Extra meta data (can be stringify JSON)"))
+
+    def __str__(self):
+        return "%s-campaign" % str(self.element)

--- a/djaopsp/templates/pages/app/sequences/index.html
+++ b/djaopsp/templates/pages/app/sequences/index.html
@@ -1,0 +1,51 @@
+{% extends "base.html" %}
+
+{% block content %}
+<h2>{{ sequence.title }}</h2>
+<section id="app">
+    <sequence-items inline-template>
+        <div>
+            <div v-if="itemsLoaded">
+                <ul>
+                    {% for element in elements %}
+                    <li>
+                        {% if element.is_live_event %}
+                            <span class="live-event-label">
+                                <a href="{{ element.url }}">
+                            {{ element.title }}</a>({{ element.rank }}) -
+                                Live Event:</span>
+                        {% elif element.is_survey_event %}
+                            <span class="survey-event-label">
+                                <a href="{{ element.url }}">
+                            {{ element.title }}</a>({{ element.rank }}) -
+                                Survey:</span>
+                        {% elif element.is_certificate %}
+                            <span class="certificate-label">
+                            <a href="{{ urls.certificate_download }}">
+                                {{ element.title }}</a>({{ element.rank }}) - Certificate
+                            </span>
+                        {% else %}
+                        <a href="{{ element.url }}">
+                            {{ element.title }}</a>({{ element.rank }}) -
+
+                        <span v-if="items.results.some(item => item.rank === {{ element.rank }})">
+                            <template v-for="item in items.results">
+                                <span v-if="item.rank === {{ element.rank }}">
+                                    [[ item.viewing_duration | formatDuration ]]
+                                </span>
+                            </template>
+                        </span>
+                        <span v-else>
+                            No progress yet
+                        </span>
+                    {% endif %}
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+{#            {% include '_paginator.html' %}#}
+        </div>
+    </sequence-items>
+</section>
+{% endblock %}
+

--- a/djaopsp/templates/pages/app/sequences/index.html
+++ b/djaopsp/templates/pages/app/sequences/index.html
@@ -1,4 +1,4 @@
-{% extends "base.html" %}
+{% extends "app/base.html" %}
 
 {% block content %}
 <h2>{{ sequence.title }}</h2>
@@ -13,12 +13,12 @@
                             <span class="live-event-label">
                                 <a href="{{ element.url }}">
                             {{ element.title }}</a>({{ element.rank }}) -
-                                Live Event:</span>
+                                Live Event</span>
                         {% elif element.is_survey_event %}
                             <span class="survey-event-label">
                                 <a href="{{ element.url }}">
                             {{ element.title }}</a>({{ element.rank }}) -
-                                Survey:</span>
+                                Survey</span>
                         {% elif element.is_certificate %}
                             <span class="certificate-label">
                             <a href="{{ urls.certificate_download }}">
@@ -49,3 +49,7 @@
 </section>
 {% endblock %}
 
+{% block app_bodyscripts %}
+    <script type="text/javascript" src="{{'/static/js/djaodjin-resources-vue.js'|asset}}"></script>
+    <script type="text/javascript" src="{{'/static/js/djaodjin-pages-vue.js'|asset}}"></script>
+{% endblock %}

--- a/djaopsp/templates/pages/app/sequences/pageelement.html
+++ b/djaopsp/templates/pages/app/sequences/pageelement.html
@@ -1,0 +1,75 @@
+{% extends "app/base.html" %}
+
+{% block content %}
+    <br>
+    <a href="{{ urls.sequence_progress_view }}">
+        Back to {{ sequence.slug }}
+    </a>
+
+    <h1>{{ element.page_element.title }}</h1>
+    {% if element.page_element.text %}
+        <hr>
+        <p>{{ element.page_element.text|safe }}</p>
+        <hr>
+    {% endif %}
+
+    {% if element.is_live_event %}
+        <p>Live Event URL: <a href="{{ urls.live_event_location }}">{{ urls.live_event_location }}</a></p>
+    
+    {% elif element.is_survey_event %}
+        <p>This is a Survey. </p>
+        <!-- Need to add more details about the Survey here -->
+    {% elif element.is_certificate %}
+        <p>This is a certificate. <a href="{{ urls.certificate_download }}">Download Certificate</a></p>
+    {% else %}
+        {% if not progress %}
+            <p>No progress yet!</p>
+            <section id="app">
+                <start-progress inline-template
+                    :sequence-slug="'{{ sequence.slug }}'"
+                    :user-username="'{{ request.user.username }}'"
+                    :element-rank="{{ element.rank }}">
+                    <div>
+                        <button id="startProgress" @click="startProgress">Start Progress</button>
+                            <input type="hidden" name="csrfmiddlewaretoken" value="{{csrf_token}}">
+
+                        <p>Click the button to start tracking your progress.</p>
+                    </div>
+                </start-progress>
+            </section>
+        {% else %}
+            <section id="app">
+                <viewing-timer inline-template
+                    :initial-duration="{{ viewing_duration_seconds }}"
+                    :rank="{{ element.rank }}"
+                    :sequence="'{{ sequence.slug }}'"
+                    :user="'{{ request.user.username }}'"
+                    :ping-interval="{{ ping_interval }}">
+                    <div>
+                        <label>Viewing Duration:</label> <span>[[ duration | formatDuration ]]</span>
+                        <input type="hidden" name="csrfmiddlewaretoken" value="{{csrf_token}}">
+                    </div>
+                </viewing-timer>
+            </section>
+        {% endif %}
+    {% endif %}
+
+    {% if previous_element %}
+        <a href="{{ previous_element.url }}">
+            Previous
+        </a>
+    {% endif %}
+
+    {% if next_element %}
+        <a href="{{ next_element.url }}">
+            Next
+        </a>
+    {% endif %}
+    <br>
+
+{% endblock %}
+{% block app_bodyscripts %}
+    <script type="text/javascript" src="{{'/static/js/djaodjin-resources-vue.js'|asset}}"></script>
+    <script type="text/javascript" src="{{'/static/js/djaodjin-pages-vue.js'|asset}}"></script>
+
+{% endblock %}

--- a/djaopsp/templates/pages/certificate.html
+++ b/djaopsp/templates/pages/certificate.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Certificate of Completion</title>
+</head>
+<body>
+{{ certificate.text|safe }}
+    <div class="certificate">
+        <div>Certificate of Completion</div>
+        <div>This is to certify that</div>
+        <div>{{ user.username }}</div>
+        <div>
+            has successfully completed the <strong>{{ sequence.title }}</strong> sequence.
+        </div>
+        <div>Date: {{ completion_date }}</div>
+    </div>
+</body>
+</html>

--- a/djaopsp/templatetags/djaopsp_tags.py
+++ b/djaopsp/templatetags/djaopsp_tags.py
@@ -175,3 +175,7 @@ def not_key(param_name):
     return not (param_name.lower() == 'password'
             or param_name.lower().endswith('_key')
             or param_name.lower().endswith('_password'))
+
+@register.filter
+def get_item(dictionary, key):
+    return dictionary.get(key)

--- a/djaopsp/urls/api/__init__.py
+++ b/djaopsp/urls/api/__init__.py
@@ -15,18 +15,16 @@ from ...api.content import (PageElementAPIView, PageElementIndexAPIView,
 from ...api.samples import RespondentsAPIView
 
 urlpatterns = [
-    path('sequences/',
+    path('sequences',
          SequenceListCreateAPIView.as_view(),
          name='api_sequence_list_create'),
-    path('sequences/<slug:sequence>/',
+    path('sequences/<slug:sequence>',
          SequenceRetrieveUpdateDestroyAPIView.as_view(),
          name='api_sequence_retrieve_update_destroy'),
-    path('sequences/<slug:sequence>/elements/',
+    path('sequences/<slug:sequence>/elements',
          AddElementToSequenceAPIView.as_view(),
          name='api_add_element_to_sequence'),
-    # Need to update path to allow adding using negative ranks
-    # Bugs out when using negative ranks.
-    re_path(r'sequences/(?P<sequence>[^/]+)/elements/(?P<rank>-?\d+)/',
+    re_path(r'sequences/(?P<sequence>[^/]+)/elements/(?P<rank>-?\d+)',
             RemoveElementFromSequenceAPIView.as_view(),
             name='api_remove_element_from_sequence'),
     path('respondents', RespondentsAPIView.as_view(),

--- a/djaopsp/urls/api/__init__.py
+++ b/djaopsp/urls/api/__init__.py
@@ -4,16 +4,31 @@
 """
 API URLs
 """
-from django.urls import path, include
+from django.urls import path, include, re_path
 from pages.api.elements import (PageElementSearchAPIView,
     PageElementDetailAPIView)
+from pages.api.sequences import (SequenceRetrieveUpdateDestroyAPIView,
+    SequenceListCreateAPIView, RemoveElementFromSequenceAPIView, AddElementToSequenceAPIView)
 
 from ...api.content import (PageElementAPIView, PageElementIndexAPIView,
     PageElementEditableListAPIView)
 from ...api.samples import RespondentsAPIView
 
-
 urlpatterns = [
+    path('sequences/',
+         SequenceListCreateAPIView.as_view(),
+         name='api_sequence_list_create'),
+    path('sequences/<slug:sequence>/',
+         SequenceRetrieveUpdateDestroyAPIView.as_view(),
+         name='api_sequence_retrieve_update_destroy'),
+    path('sequences/<slug:sequence>/elements/',
+         AddElementToSequenceAPIView.as_view(),
+         name='api_add_element_to_sequence'),
+    # Need to update path to allow adding using negative ranks
+    # Bugs out when using negative ranks.
+    re_path(r'sequences/(?P<sequence>[^/]+)/elements/(?P<rank>-?\d+)/',
+            RemoveElementFromSequenceAPIView.as_view(),
+            name='api_remove_element_from_sequence'),
     path('respondents', RespondentsAPIView.as_view(),
          name='api_respondents'),
     path('content/editables/<slug:profile>',
@@ -22,6 +37,7 @@ urlpatterns = [
     path('content/editables/<slug:profile>/',
          include('djaopsp.urls.api.editors')),
     path('content/', include('pages.urls.api.readers')),
+    path('progress/', include('pages.urls.api.progress')),
     path('content/search',
         PageElementSearchAPIView.as_view(), name='api_page_element_search'),
     path('content/detail/<path:path>',

--- a/djaopsp/urls/views/__init__.py
+++ b/djaopsp/urls/views/__init__.py
@@ -15,9 +15,13 @@ from ...views.assess import TrackMetricsView, AssessPracticesView
 from ...views.content import ContentDetailView, ContentIndexView
 from ...views.scorecard import (ScorecardIndexView, ScorecardHistoryView,
     ScorecardRedirectView)
+from pages.views.elements import CertificateDownloadView
 
 
 urlpatterns = [
+    path('<slug:sequence>/certificate/',
+         CertificateDownloadView.as_view(),
+         name='certificate_download'),
     path('app/reporting/',
         AccountRedirectView.as_view(
             pattern_name='portfolio_engage'),

--- a/djaopsp/urls/views/__init__.py
+++ b/djaopsp/urls/views/__init__.py
@@ -15,13 +15,9 @@ from ...views.assess import TrackMetricsView, AssessPracticesView
 from ...views.content import ContentDetailView, ContentIndexView
 from ...views.scorecard import (ScorecardIndexView, ScorecardHistoryView,
     ScorecardRedirectView)
-from pages.views.elements import CertificateDownloadView
 
 
 urlpatterns = [
-    path('<slug:sequence>/certificate/',
-         CertificateDownloadView.as_view(),
-         name='certificate_download'),
     path('app/reporting/',
         AccountRedirectView.as_view(
             pattern_name='portfolio_engage'),

--- a/djaopsp/urls/views/content.py
+++ b/djaopsp/urls/views/content.py
@@ -4,12 +4,17 @@
 """
 Views URLs
 """
-from django.urls import path
-
-from ...views.content import ContentDetailView, ContentIndexView
+from django.urls import path, re_path
+from ...views.content import (ContentDetailView, ContentIndexView, 
+     SequenceProgressView, SequencePageElementView)
 
 
 urlpatterns = [
+    path('sequences/<slug:sequence>/', 
+         SequenceProgressView.as_view(), name='sequence_progress_view'),
+    re_path(r'sequences/(?P<sequence>[^/]+)/(?P<rank>-?\d+)/',
+          SequencePageElementView.as_view(),
+          name='sequence_page_element_view'),
     path('<path:path>/',
          ContentDetailView.as_view(), name='pages_element'),
     path('',

--- a/djaopsp/urls/views/content.py
+++ b/djaopsp/urls/views/content.py
@@ -7,6 +7,7 @@ Views URLs
 from django.urls import path, re_path
 from ...views.content import (ContentDetailView, ContentIndexView, 
      SequenceProgressView, SequencePageElementView)
+from pages.views.elements import CertificateDownloadView
 
 
 urlpatterns = [
@@ -15,6 +16,9 @@ urlpatterns = [
     re_path(r'sequences/(?P<sequence>[^/]+)/(?P<rank>-?\d+)/',
           SequencePageElementView.as_view(),
           name='sequence_page_element_view'),
+    path('sequences/<slug:sequence>/certificate/',
+         CertificateDownloadView.as_view(),
+         name='certificate_download'),
     path('<path:path>/',
          ContentDetailView.as_view(), name='pages_element'),
     path('',

--- a/djaopsp/views/content.py
+++ b/djaopsp/views/content.py
@@ -2,9 +2,30 @@
 # see LICENSE.
 
 from pages.views.elements import PageElementView, PageElementEditableView
+from pages.views.sequences import (SequenceProgressView as BaseSequenceProgressView, 
+    SequencePageElementView as BaseSequencePageElementView)
 
 from ..mixins import AccountMixin
+from ..models import SurveyEvent
 
+class SequenceProgressView(BaseSequenceProgressView):
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        elements = context.get('elements', [])
+
+        for element in elements:
+            element.is_survey_event = SurveyEvent.objects.filter(element=element.page_element).exists()
+        
+        context['elements'] = elements
+        
+        return context
+
+class SequencePageElementView(BaseSequencePageElementView):
+
+    def get_object(self, queryset=None):
+        element = super().get_object(queryset)
+        element.is_survey_event = SurveyEvent.objects.filter(element=element.page_element).exists()
+        return element
 
 class ContentIndexView(PageElementView):
     """

--- a/djaopsp/views/content.py
+++ b/djaopsp/views/content.py
@@ -5,27 +5,13 @@ from pages.views.elements import PageElementView, PageElementEditableView
 from pages.views.sequences import (SequenceProgressView as BaseSequenceProgressView, 
     SequencePageElementView as BaseSequencePageElementView)
 
-from ..mixins import AccountMixin
-from ..models import SurveyEvent
+from ..mixins import AccountMixin, SequenceProgressMixin
 
-class SequenceProgressView(BaseSequenceProgressView):
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        elements = context.get('elements', [])
+class SequenceProgressView(SequenceProgressMixin, BaseSequenceProgressView):
+    pass
 
-        for element in elements:
-            element.is_survey_event = SurveyEvent.objects.filter(element=element.page_element).exists()
-        
-        context['elements'] = elements
-        
-        return context
-
-class SequencePageElementView(BaseSequencePageElementView):
-
-    def get_object(self, queryset=None):
-        element = super().get_object(queryset)
-        element.is_survey_event = SurveyEvent.objects.filter(element=element.page_element).exists()
-        return element
+class SequencePageElementView(SequenceProgressMixin, BaseSequencePageElementView):
+    pass
 
 class ContentIndexView(PageElementView):
     """


### PR DESCRIPTION
- Added fixtures for Sequence with text, live-event, survey, and certificate
- Added a SurveyEvent model.
- Added templates from Djaodjin-Pages
- Subclassed the front-end views and slightly updated them to accommodate survey events.

Currently working on:
- Vue isn't being integrated correctly, don't know where exactly the issue is but on the 'sequence_progress_view' text-content says "No progress yet" on a text content that does have progress. It works fine on 'sequence_page_element_view'
- Correct URL locations