### PR TITLE
Fixes #164 and Bootstrap v4->v5 compatibility bugs

### DIFF
--- a/djaopsp/sustainability/templates/app/reporting/sustainability.html
+++ b/djaopsp/sustainability/templates/app/reporting/sustainability.html
@@ -73,16 +73,14 @@
                            v-on:selectitem="addAccount">
           <form  class="form-inline" @submit.prevent="search">
             <div class="input-group mb-3">
-              <div class="input-group-prepend">
-                <!-- optional indicators -->
-                <span class="input-group-text">
-                  <i class="fa fa-spinner fa-spin" v-if="loading"></i>
-                  <template v-else>
-                    <i class="fa fa-search" v-show="isEmpty"></i>
-                    <i class="fa fa-times" v-show="isDirty" @click="reset"></i>
-                  </template>
-                </span>
-              </div>
+              <!-- optional indicators -->
+              <span class="input-group-text">
+                <i class="fa fa-spinner fa-spin" v-if="loading"></i>
+                <template v-else>
+                  <i class="fa fa-search" v-show="isEmpty"></i>
+                  <i class="fa fa-times" v-show="isDirty" @click="reset"></i>
+                </template>
+              </span>
               <!-- the input field -->
               <input class="form-control"
                      type="text"
@@ -105,11 +103,9 @@
                   <a v-text="item.printable_name"></a>
                 </li>
               </ul>
-              <div class="input-group-append">
-                <button class="btn btn-primary" type="submit" value="submit">
-                  Add reporting entity
-                </button>
-              </div>
+              <button class="btn btn-primary" type="submit" value="submit">
+                Add reporting entity
+              </button>
             </div>
           </form>
         </account-typeahead>

--- a/djaopsp/templates/_filter.html
+++ b/djaopsp/templates/_filter.html
@@ -12,9 +12,7 @@
     <div class="col-sm-6 col-lg-4 px-1">
       <div class="form-group">
         <div class="input-group input-group-md">
-          <div class="input-group-prepend">
-            <label class="text-monospace input-group-text" id="filter-inp">{% trans %}Match{% endtrans %}</label>
-          </div>
+          <label class="text-monospace input-group-text" id="filter-inp">{% trans %}Match{% endtrans %}</label>
           <input class="form-control" type="text" v-model="params.q" />
         </div>
       </div>

--- a/djaopsp/templates/app/reporting/accessibles/index.html
+++ b/djaopsp/templates/app/reporting/accessibles/index.html
@@ -49,29 +49,25 @@
 <reporting-organizations inline-template>
   <div>
     <div class="row">
-      <div class="col-md-6">
+      <div class="col-xl-6 col-12">
         <form id="period-update" class="mt-4"
               @submit.prevent="reload()">
           <div class="row">
-          <div class="col-sm-4">
+          <div class="col-md-5 col-6">
             <div class="input-group input-group-sm">
-              <div class="input-group-prepend">
-                <span class="input-group-text" id="from-inp">{% trans %}From{% endtrans %}</span>
-              </div>
+              <span class="input-group-text" id="from-inp">{% trans %}From{% endtrans %}</span>
               <input class="form-control" type="date" v-model="_start_at" v-cloak>
             </div>
           </div>
-          <div class="col-sm-4">
+          <div class="col-md-5 col-6">
             <div class="input-group input-group-sm">
-              <div class="input-group-prepend">
-                <span class="input-group-text" id="from-inp">{% trans %}To{% endtrans %}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
-              </div>
+              <span class="input-group-text" id="from-inp">{% trans %}To{% endtrans %}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
               <input class="form-control" type="date" v-model="_ends_at" v-cloak>
             </div>
           </div>
           </div>
           <div class="row mt-2">
-          <div class="col-sm-4">
+          <div class="col-md-5 col-6">
             <div class="input-group input-group-sm">
               <select class="form-control form-select"
                       v-model="params.period">
@@ -80,7 +76,7 @@
               </select>
             </div>
           </div>
-          <div class="col-sm-4 text-end text-right">
+          <div class="col-md-5 col-6 text-end text-right">
             <button class="btn btn-primary btn-sm"
                   :disabled="!outdated"
                   type="submit">{% trans %}Update{% endtrans %}</button>

--- a/djaopsp/templates/app/track/energy-ghg-emissions.html
+++ b/djaopsp/templates/app/track/energy-ghg-emissions.html
@@ -766,24 +766,22 @@ Electricity and other sources of energy purchased from your local utility (that 
                            <input class="form-control" type="number" min="0"
                                   name="measured"
                                   v-model="item.measured">
-                           <div class="input-group-append">
-                             <select class="form-control form-select"
-                                     name="unit"
-                                     v-model="item.unit"
-                                     v-if="item.extra.calculation_approach == 'purchased-electricity-location-based' || item.extra.calculation_approach == 'purchased-electricity-market-based'">
-                                <option value="kWh">kWh</option>
-                                <option value="mwh">MWh</option>
-                             </select>
-                             <select class="form-control form-select"
-                                     v-model="item.unit"
-                                     v-if="item.extra.calculation_approach == 'heat-steam'">
-                                <option value="btu">Btu</option>
-                                <option value="mmbtu">mmBtu</option>
-                                <option value="therm">therm</option>
-                                <option value="kWh">kWh</option>
-                                <option value="mwh">MWh</option>
-                             </select>
-                           </div>
+                            <select class="form-control form-select"
+                                    name="unit"
+                                    v-model="item.unit"
+                                    v-if="item.extra.calculation_approach == 'purchased-electricity-location-based' || item.extra.calculation_approach == 'purchased-electricity-market-based'">
+                              <option value="kWh">kWh</option>
+                              <option value="mwh">MWh</option>
+                            </select>
+                            <select class="form-control form-select"
+                                    v-model="item.unit"
+                                    v-if="item.extra.calculation_approach == 'heat-steam'">
+                              <option value="btu">Btu</option>
+                              <option value="mmbtu">mmBtu</option>
+                              <option value="therm">therm</option>
+                              <option value="kWh">kWh</option>
+                              <option value="mwh">MWh</option>
+                            </select>
                          </div>
                        </td>
                      </tr>

--- a/djaopsp/templates/app/track/waste.html
+++ b/djaopsp/templates/app/track/waste.html
@@ -97,17 +97,15 @@
                             <input class="form-control" type="number" min="0"
                                    name="measured"
                                    v-model="item.measured">
-                            <div class="input-group-append">
-                              <select class="form-control form-select"
-                                   name="unit" v-model="item.unit">
-                                <option value="t">Metric tons</option>
-                                <option value="lbs">Pounds</option>
-                                <option value="m3">Cubic meters (m<sup>3</sup>)</option>
-                                <option value="kiloliters">Kilo liters</option>
-                                <option value="ft3">Cubic feet (ft.<sup>3</sup>)</option>
-                                <option value="gallons">US Gallon</option>
-                              </select>
-                            </div>
+                            <select class="form-control form-select"
+                                  name="unit" v-model="item.unit">
+                              <option value="t">Metric tons</option>
+                              <option value="lbs">Pounds</option>
+                              <option value="m3">Cubic meters (m<sup>3</sup>)</option>
+                              <option value="kiloliters">Kilo liters</option>
+                              <option value="ft3">Cubic feet (ft.<sup>3</sup>)</option>
+                              <option value="gallons">US Gallon</option>
+                            </select>
                           </div>
                         </td>
                       </tr>

--- a/djaopsp/templates/app/track/water.html
+++ b/djaopsp/templates/app/track/water.html
@@ -95,18 +95,16 @@
                             <input class="form-control" type="number" min="0"
                                    name="measured"
                                    v-model="item.measured">
-                            <div class="input-group-append">
-                              <select class="form-control form-select"
-                                   name="unit"
-                                   v-model="item.unit">
-                                <option value="t">Metric tons</option>
-                                <option value="lbs">Pounds</option>
-                                <option value="m3">Cubic meters (m<sup>3</sup>)</option>
-                                <option value="kiloliters">Kilo liters</option>
-                                <option value="ft3">Cubic feet (ft.<sup>3</sup>)</option>
-                                <option value="gallons">US Gallon</option>
-                              </select>
-                            </div>
+                            <select class="form-control form-select"
+                                  name="unit"
+                                  v-model="item.unit">
+                              <option value="t">Metric tons</option>
+                              <option value="lbs">Pounds</option>
+                              <option value="m3">Cubic meters (m<sup>3</sup>)</option>
+                              <option value="kiloliters">Kilo liters</option>
+                              <option value="ft3">Cubic feet (ft.<sup>3</sup>)</option>
+                              <option value="gallons">US Gallon</option>
+                            </select>
                           </div>
                         </td>
                       </tr>
@@ -190,17 +188,15 @@
                           <div class="input-group">
                             <input class="form-control" type="number" min="0"
                                    name="measured" v-model="item.measured">
-                            <div class="input-group-append">
-                              <select class="form-control form-select"
-                                   name="unit" v-model="item.unit">
-                                <option value="t">Metric tons</option>
-                                <option value="lbs">Pounds</option>
-                                <option value="m3">Cubic meters (m<sup>3</sup>)</option>
-                                <option value="kiloliters">Kilo liters</option>
-                                <option value="ft3">Cubic feet (ft.<sup>3</sup>)</option>
-                                <option value="gallons">US Gallon</option>
-                              </select>
-                            </div>
+                            <select class="form-control form-select"
+                                  name="unit" v-model="item.unit">
+                              <option value="t">Metric tons</option>
+                              <option value="lbs">Pounds</option>
+                              <option value="m3">Cubic meters (m<sup>3</sup>)</option>
+                              <option value="kiloliters">Kilo liters</option>
+                              <option value="ft3">Cubic feet (ft.<sup>3</sup>)</option>
+                              <option value="gallons">US Gallon</option>
+                            </select>
                           </div>
                         </td>
                       </tr>
@@ -290,18 +286,16 @@
                             <input class="form-control" type="number" min="0"
                                    name="measured"
                                    v-model="item.measured">
-                            <div class="input-group-append">
-                              <select class="form-control form-select"
-                                   name="unit"
-                                   v-model="item.unit">
-                                <option value="t">Metric tons</option>
-                                <option value="lbs">Pounds</option>
-                                <option value="m3">Cubic meters (m<sup>3</sup>)</option>
-                                <option value="kiloliters">Kilo liters</option>
-                                <option value="ft3">Cubic feet (ft.<sup>3</sup>)</option>
-                                <option value="gallons">US Gallon</option>
-                              </select>
-                            </div>
+                            <select class="form-control form-select"
+                                  name="unit"
+                                  v-model="item.unit">
+                              <option value="t">Metric tons</option>
+                              <option value="lbs">Pounds</option>
+                              <option value="m3">Cubic meters (m<sup>3</sup>)</option>
+                              <option value="kiloliters">Kilo liters</option>
+                              <option value="ft3">Cubic feet (ft.<sup>3</sup>)</option>
+                              <option value="gallons">US Gallon</option>
+                            </select>
                           </div>
                         </td>
                       </tr>

--- a/djaopsp/templates/jinja2/_form_fields.html
+++ b/djaopsp/templates/jinja2/_form_fields.html
@@ -29,23 +29,18 @@
 <div class="form-group{% if errors %} has-error{% endif %}">
   <div class="input-group input-group-md">
     {% if not hide_labels %}
-    <div class="input-group-prepend">
       <label class="text-monospace input-group-text{% if required %} requiredField{% endif %}">{{label|safe}}</label>
-    </div>
     {% endif %}
     {% if nameOpened %}
     <span class="form-control"
           v-show="!{{nameOpened}} && !{{name}}">{% trans %}Never{% endtrans %}</span>
-    <div class="input-group-append"
-         v-show="!{{nameOpened}} && !{{name}}">
-      <button class="input-group-text"
+      <button class="input-group-text" v-show="!{{nameOpened}} && !{{name}}"
               {% if disabled %}
               disabled
               {% else %}
               @click.prevent="{{toggleNameOpened}}"
               {% endif %}
               ><span class="fa-solid fa-calendar"></span></button>
-    </div>
     {% endif %}
     <input class="form-control{% if errors %} is-invalid{% endif %}"
            type="date"

--- a/djaopsp/templates/pages/index.html
+++ b/djaopsp/templates/pages/index.html
@@ -17,17 +17,13 @@
                 <div class="col-md-6">
                   <form id="search" @submit.prevent="reload()">
                     <div class="input-group input-group-sm">
-                      <div class="input-group-prepend">
-                        <span class="input-group-text" id="from-inp"><i class="fa-solid fa-search"></i></span>
-                      </div>
+                      <span class="input-group-text" id="from-inp"><i class="fa-solid fa-search"></i></span>
                       <input class="form-control"
                              type="text"
                              placeholder="{% trans %}Ex: GHG Emissions ...{% endtrans %}"
                              v-model="params.q" />
-                      <div class="input-group-append">
-                        <button class="btn btn-primary btn-sm"
-                                type="submit">{% trans %}Search{% endtrans %}</button>
-                      </div>
+                      <button class="btn btn-primary btn-sm"
+                              type="submit">{% trans %}Search{% endtrans %}</button>
                     </div>
                   </form>{# /#search #}
                 </div>


### PR DESCRIPTION
E.g "Date fields From/To on accessibles page are too small"

I fixed this issue, but I also noticed that there in Bootstrap v5 `.input-group-append` and `.input-group-prepend` containers are no longer needed, so I looked through the codebase and removed these. It should also improve the UI of the fixed components, see example:


<img width="406" height="70" alt="Screenshot 2026-06-02 at 12 59 16 AM" src="https://github.com/user-attachments/assets/773367ff-6470-4564-9741-b816ee2ad79c" />
<img width="410" height="47" alt="Screenshot 2026-06-02 at 12 59 20 AM" src="https://github.com/user-attachments/assets/2249eda3-9a3d-4326-b90a-a5e256567840" />

