### PR TITLE
Add support for multiple recipients for "re-send" invitation

### DIFF
--- a/djaopsp/notifications/serializers.py
+++ b/djaopsp/notifications/serializers.py
@@ -46,12 +46,15 @@ class PortfolioNotificationSerializer(NotificationSerializer):
     message = serializers.CharField(required=False, allow_null=True)
     recipients = serializers.ListField(child=UserDetailSerializer(),
         required=False, allow_null=True)
+    cc = serializers.ListField(
+        child=serializers.EmailField(),
+        required=False, default=list)
 
     class Meta:
         fields = ('grantee', 'account', 'campaign', 'last_completed_at',
-            'message', 'recipients')
+            'message', 'recipients', 'cc')
         read_only_fields = ('grantee', 'account', 'campaign',
-            'last_completed_at',)
+            'last_completed_at', 'cc')
 
 
 class SampleFrozenNotificationSerializer(NotificationSerializer):

--- a/djaopsp/notifications/serializers.py
+++ b/djaopsp/notifications/serializers.py
@@ -46,15 +46,12 @@ class PortfolioNotificationSerializer(NotificationSerializer):
     message = serializers.CharField(required=False, allow_null=True)
     recipients = serializers.ListField(child=UserDetailSerializer(),
         required=False, allow_null=True)
-    cc = serializers.ListField(
-        child=serializers.EmailField(),
-        required=False, default=list)
 
     class Meta:
         fields = ('grantee', 'account', 'campaign', 'last_completed_at',
-            'message', 'recipients', 'cc')
+            'message', 'recipients')
         read_only_fields = ('grantee', 'account', 'campaign',
-            'last_completed_at', 'cc')
+            'last_completed_at',)
 
 
 class SampleFrozenNotificationSerializer(NotificationSerializer):

--- a/djaopsp/notifications/signals.py
+++ b/djaopsp/notifications/signals.py
@@ -82,7 +82,7 @@ def portfolios_grant_initiated_notice(sender, portfolios, recipients, message,
 @receiver(portfolios_request_initiated,
     dispatch_uid="portfolios_request_initiated_notice")
 def portfolios_request_initiated_notice(sender, portfolios, recipients,
-                                        message, request, cc=None, **kwargs):
+                                        message, request, **kwargs):
     """
     Portfolio request initiated
 
@@ -106,7 +106,7 @@ def portfolios_request_initiated_notice(sender, portfolios, recipients,
 
     portfolio = portfolios[0] # XXX first one only
     LOGGER.debug("[signal] portfolios_request_initiated_notice("\
-        "portfolio=%s, recipients=%s, cc=%s)", portfolio, recipients, cc)
+        "portfolio=%s, recipients=%s)", portfolio, recipients)
 
     back_url = request.build_absolute_uri(reverse('profile_getstarted', args=(
         portfolio.account,)))
@@ -122,8 +122,7 @@ def portfolios_request_initiated_notice(sender, portfolios, recipients,
         'grantee': portfolio.grantee,
         'originated_by': request.user,
         'message': message,
-        'recipients': recipients,
-        'cc': cc or []
+        'recipients': recipients
     }
     send_notification('portfolios_request_initiated',
       context=PortfolioNotificationSerializer().to_representation(context))

--- a/djaopsp/notifications/signals.py
+++ b/djaopsp/notifications/signals.py
@@ -82,7 +82,7 @@ def portfolios_grant_initiated_notice(sender, portfolios, recipients, message,
 @receiver(portfolios_request_initiated,
     dispatch_uid="portfolios_request_initiated_notice")
 def portfolios_request_initiated_notice(sender, portfolios, recipients,
-                                        message, request, **kwargs):
+                                        message, request, cc=None, **kwargs):
     """
     Portfolio request initiated
 
@@ -100,10 +100,13 @@ def portfolios_request_initiated_notice(sender, portfolios, recipients,
     #pylint:disable=unused-argument
     if not recipients:
         recipients = []
+    recipients = [rcpt for rcpt in recipients
+        if (rcpt.get('email') if isinstance(rcpt, dict)
+            else rcpt.email)]
 
     portfolio = portfolios[0] # XXX first one only
     LOGGER.debug("[signal] portfolios_request_initiated_notice("\
-        "portfolio=%s, recipients=%s)", portfolio, recipients)
+        "portfolio=%s, recipients=%s, cc=%s)", portfolio, recipients, cc)
 
     back_url = request.build_absolute_uri(reverse('profile_getstarted', args=(
         portfolio.account,)))
@@ -119,7 +122,8 @@ def portfolios_request_initiated_notice(sender, portfolios, recipients,
         'grantee': portfolio.grantee,
         'originated_by': request.user,
         'message': message,
-        'recipients': recipients
+        'recipients': recipients,
+        'cc': cc or []
     }
     send_notification('portfolios_request_initiated',
       context=PortfolioNotificationSerializer().to_representation(context))

--- a/djaopsp/static/js/reporting-vue.js
+++ b/djaopsp/static/js/reporting-vue.js
@@ -278,15 +278,17 @@ Vue.component('engage-profiles', {
                         var {accounts, ...rest} = data;
                         flat = {...rest, ...accounts[0]};
                     }
-                    if( flat.cc ) {
-                        var ccErrors = [];
-                        for( var key in flat.cc ) {
-                            if( flat.cc.hasOwnProperty(key) ) {
-                                ccErrors = ccErrors.concat(flat.cc[key]);
+                    if( flat.email && typeof flat.email === 'object' ) {
+                        var emailErrors = [];
+                        for( var idx in flat.email ) {
+                            if( flat.email.hasOwnProperty(idx) ) {
+                                flat.email[idx].forEach(function(msg) {
+                                    emailErrors.push("Email " +
+                                        (parseInt(idx) + 1) + ": " + msg);
+                                });
                             }
                         }
-                        flat.email = (flat.email || []).concat(ccErrors);
-                        delete flat.cc;
+                        flat.email = emailErrors;
                     }
                     errorResp = {responseJSON: flat};
                 }
@@ -310,8 +312,7 @@ Vue.component('engage-profiles', {
                     .split(',').map(function(e) { return e.trim(); })
                     .filter(function(e) { return e; });
                 if( emails.length > 0 ) {
-                    data.accounts[0].email = emails[0];
-                    data.cc = emails.slice(1);
+                    data.accounts[0].email = emails;
                 } else {
                     showErrorMessages({responseJSON: {
                         email: ["Enter a valid email address."]}});

--- a/djaopsp/static/js/reporting-vue.js
+++ b/djaopsp/static/js/reporting-vue.js
@@ -209,6 +209,7 @@ Vue.component('engage-profiles', {
         },
         populateInvite: function(newAccount) {
             var vm = this;
+            clearMessages();
             vm.newItem = {ends_at: null};
             if( newAccount.hasOwnProperty('slug') && newAccount.slug ) {
                 vm.newItem.slug = newAccount.slug;
@@ -278,17 +279,18 @@ Vue.component('engage-profiles', {
                         var {accounts, ...rest} = data;
                         flat = {...rest, ...accounts[0]};
                     }
-                    if( flat.email && typeof flat.email === 'object' ) {
-                        var emailErrors = [];
-                        for( var idx in flat.email ) {
-                            if( flat.email.hasOwnProperty(idx) ) {
-                                flat.email[idx].forEach(function(msg) {
-                                    emailErrors.push("Email " +
-                                        (parseInt(idx) + 1) + ": " + msg);
+                    if( flat.recipients && typeof flat.recipients === 'object' ) {
+                        var emailErrors = flat.email || [];
+                        for( var idx in flat.recipients ) {
+                            if( flat.recipients.hasOwnProperty(idx) ) {
+                                flat.recipients[idx].forEach(function(msg) {
+                                    emailErrors.push(
+                                        `Email ${parseInt(idx) + 2}: ${msg}`);
                                 });
                             }
                         }
                         flat.email = emailErrors;
+                        delete flat.recipients;
                     }
                     errorResp = {responseJSON: flat};
                 }
@@ -312,7 +314,8 @@ Vue.component('engage-profiles', {
                     .split(',').map(function(e) { return e.trim(); })
                     .filter(function(e) { return e; });
                 if( emails.length > 0 ) {
-                    data.accounts[0].email = emails;
+                    data.accounts[0].email = emails[0];
+                    data.accounts[0].recipients = emails.slice(1);
                 } else {
                     showErrorMessages({responseJSON: {
                         email: ["Enter a valid email address."]}});

--- a/djaopsp/static/js/reporting-vue.js
+++ b/djaopsp/static/js/reporting-vue.js
@@ -269,6 +269,29 @@ Vue.component('engage-profiles', {
         },
         requestAssessment: function($event, campaign) {
             var vm = this;
+            function handleError(resp) {
+                var errorResp = resp;
+                var data = resp.data || resp.responseJSON;
+                if( data ) {
+                    var flat = data;
+                    if( data.accounts?.length > 0 ) {
+                        var {accounts, ...rest} = data;
+                        flat = {...rest, ...accounts[0]};
+                    }
+                    if( flat.cc ) {
+                        var ccErrors = [];
+                        for( var key in flat.cc ) {
+                            if( flat.cc.hasOwnProperty(key) ) {
+                                ccErrors = ccErrors.concat(flat.cc[key]);
+                            }
+                        }
+                        flat.email = (flat.email || []).concat(ccErrors);
+                        delete flat.cc;
+                    }
+                    errorResp = {responseJSON: flat};
+                }
+                showErrorMessages(errorResp);
+            }
             var data = {
                 accounts: [{}],
                 message: vm.message,
@@ -282,6 +305,13 @@ Vue.component('engage-profiles', {
                     data.accounts[0][key] = vm.newItem[key];
                 }
             }
+            if( data.accounts[0].email ) {
+                var emails = data.accounts[0].email
+                    .split(',').map(function(e) { return e.trim(); })
+                    .filter(function(e) { return e; });
+                data.accounts[0].email = emails[0];
+                data.cc = emails.slice(1);
+            }
             if( typeof campaign !== 'undefined' ) {
                 data['campaign'] = campaign;
             }
@@ -290,7 +320,7 @@ Vue.component('engage-profiles', {
                 function success(resp, textStatus, jqXHR) {
                     showMessages(resp.detail, 'info');
                     vm.hideModal($event);
-                });
+                }, handleError);
             } else {
                 if( !vm.newItem.slug ) {
                     vm.reqPost(vm.$urls.api_account_candidates, vm.newItem,
@@ -338,7 +368,7 @@ Vue.component('engage-profiles', {
                             }
                         }
                         vm.hideModal($event);
-                    });
+                    }, handleError);
                 }
             }
             return false;

--- a/djaopsp/static/js/reporting-vue.js
+++ b/djaopsp/static/js/reporting-vue.js
@@ -309,8 +309,14 @@ Vue.component('engage-profiles', {
                 var emails = data.accounts[0].email
                     .split(',').map(function(e) { return e.trim(); })
                     .filter(function(e) { return e; });
-                data.accounts[0].email = emails[0];
-                data.cc = emails.slice(1);
+                if( emails.length > 0 ) {
+                    data.accounts[0].email = emails[0];
+                    data.cc = emails.slice(1);
+                } else {
+                    showErrorMessages({responseJSON: {
+                        email: ["Enter a valid email address."]}});
+                    return;
+                }
             }
             if( typeof campaign !== 'undefined' ) {
                 data['campaign'] = campaign;

--- a/djaopsp/templates/app/reporting/_completion_rate.html
+++ b/djaopsp/templates/app/reporting/_completion_rate.html
@@ -3,7 +3,7 @@
     <div class="col-md-6">
       <form id="period-update" class="row mt-4"
             @submit.prevent="reload()">
-        <div class="col-sm-4">
+        <div class="col-xl-5 col-12">
           <div class="input-group input-group-sm">
             <span class="input-group-text" id="from-inp">{% trans %}From{% endtrans %}</span>
             <input class="form-control" type="date" v-model="_start_at"
@@ -11,7 +11,7 @@
                 v-cloak>
           </div>
         </div>
-        <div class="col-sm-4">
+        <div class="col-xl-5 mt-xl-0 col-12 mt-2">
           <div class="input-group input-group-sm">
             <span class="input-group-text" id="from-inp">{% trans %}To{% endtrans %}&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</span>
             <input class="form-control" type="date" v-model="_ends_at"
@@ -19,7 +19,7 @@
                 v-cloak>
           </div>
         </div>
-        <div class="col-sm-4 d-print-none">
+        <div class="col-sm-2 d-print-none mt-xl-0 mt-2">
           <button class="btn btn-primary btn-sm"
                   :disabled="!outdated"
                   type="submit">{% trans %}Update{% endtrans %}</button>

--- a/djaopsp/templates/app/reporting/_invite_reporting_profile.html
+++ b/djaopsp/templates/app/reporting/_invite_reporting_profile.html
@@ -21,26 +21,28 @@
           </p>
           <div class="form-group">
             <div class="controls">
-              <label>{% trans %}Organization/profile name{% endtrans %}</label>
-              <input class="form-control w-100"
+              <label for="new-request-full-name">{% trans %}Organization/profile name{% endtrans %}</label>
+              <input id="new-request-full-name" class="form-control w-100"
                      v-model="newItem.full_name"
                      name="full_name" type="text" max-length="150"
                      :disabled="newItem.slug" />
+              <div class="invalid-feedback"></div>
             </div>
           </div>
           <div class="form-group">
             <div class="controls">
-              <label>{% trans %}To{% endtrans %}</label>
-              <input id="new-request-email" class="email w-100"
+              <label for="new-request-email">{% trans %}To{% endtrans %}</label>
+              <input id="new-request-email" class="form-control email w-100"
                      name="email" v-model="newItem.email" type="text"
                      max-length="150" placeholder="invitee@example.com"
-                     autofocus />
+                     required autofocus />
+              <div class="invalid-feedback"></div>
             </div>
           </div>
           <div id="div_id_new_user_relation" class="form-group">
             <div class="controls">
-              <label>{% trans %}The following message will be sent (or modify the message by typing in the box below).{% endtrans %}</label>
-              <textarea class="form-control" name="message"
+              <label for="new-request-message">{% trans %}The following message will be sent (or modify the message by typing in the box below).{% endtrans %}</label>
+              <textarea id="new-request-message" class="form-control" name="message"
                         type="text" rows="10"
                         v-model="message">
               </textarea>
@@ -54,10 +56,10 @@
             </div>
           </div>
           <div>
-            <label>
+            <label for="new-request-expires-at">
             {% trans %}Expect a response before:{% endtrans %}
             </label>
-            <input class="form-control" type="date" v-model="_expires_at" v-cloak>
+            <input id="new-request-expires-at" class="form-control" type="date" v-model="_expires_at" v-cloak>
           </div>
         </div>
         <div class="modal-footer">

--- a/djaopsp/utils.py
+++ b/djaopsp/utils.py
@@ -117,9 +117,10 @@ def _notified_recipients(notification_slug, context):
         user_email = context.get('account', {}).get('email', "")
         if user_email:
             recipients = [user_email]
-        for email in context.get('cc', []):
-            if email not in recipients:
-                recipients.append(email)
+        for rcpt in context.get('recipients', []):
+            rcpt_email = rcpt.get('email', "") if isinstance(rcpt, dict) else ""
+            if rcpt_email and rcpt_email not in recipients:
+                recipients.append(rcpt_email)
     elif notification_slug in (
             'portfolios_grant_initiated',
             'portfolio_request_accepted',):

--- a/djaopsp/utils.py
+++ b/djaopsp/utils.py
@@ -117,6 +117,9 @@ def _notified_recipients(notification_slug, context):
         user_email = context.get('account', {}).get('email', "")
         if user_email:
             recipients = [user_email]
+        for email in context.get('cc', []):
+            if email not in recipients:
+                recipients.append(email)
     elif notification_slug in (
             'portfolios_grant_initiated',
             'portfolio_request_accepted',):


### PR DESCRIPTION
There's also a related PR in djaodjin-survey: https://github.com/djaodjin/djaodjin-survey/pull/45 .
This adds support for multiple recipients, fixes error handling for nested account errors, fixes date inputs responsiveness. Additionally fixed a11y issues and a bug where user submits a re-send form without any recipients resulting in 500.